### PR TITLE
Use new-style blocking IO API in Jeepney

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 docs/srcbuild
+__pycache__/

--- a/dbus_objects/integration/jeepney.py
+++ b/dbus_objects/integration/jeepney.py
@@ -7,7 +7,7 @@ import time
 from typing import Optional
 
 import jeepney.bus_messages
-import jeepney.integrate.blocking
+import jeepney.io.blocking
 import jeepney.low_level
 import jeepney.wrappers
 
@@ -34,9 +34,8 @@ class BlockingDBusServer(dbus_objects.integration.DBusServerBase):
         self.close()  # pragma: no cover
 
     def _conn_start(self) -> None:
-        self._conn = jeepney.integrate.blocking.connect_and_authenticate(self._bus)
-        self._conn.send_and_get_reply(self._dbus.RequestName(self._name))
-        self._conn.router.on_unhandled = self._handle_msg
+        self._conn = jeepney.io.blocking.open_dbus_connection(self._bus)
+        jeepney.io.blocking.Proxy(self._dbus, self._conn).RequestName(self._name)
 
     def _handle_msg(self, msg: jeepney.low_level.Message) -> None:
         if msg.header.message_type == jeepney.low_level.MessageType.method_call:
@@ -101,10 +100,12 @@ class BlockingDBusServer(dbus_objects.integration.DBusServerBase):
         try:
             while event is None or event.is_set():
                 try:
-                    self._conn.recv_messages()
+                    msg = self._conn.receive()
                 except ConnectionResetError:
                     self.__logger.debug('connection reset abruptly, restarting...')
                     self._conn_start()
+                else:
+                    self._handle_msg(msg)
                 time.sleep(delay)
         except KeyboardInterrupt:
             self.__logger.info('exiting...')

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
 
 [options.extras_require]
 jeepney =
-    jeepney
+    jeepney >= 0.5
 test =
     pytest
     pytest-subtests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import multiprocessing
 import time
 
 import jeepney
+import jeepney.io.blocking
 import pytest
 
 from dbus_objects.integration import DBusServerBase
@@ -95,5 +96,5 @@ def jeepney_client():
 
 @pytest.fixture(scope='session')
 def jeepney_connection():
-    with jeepney.integrate.blocking.connect_and_authenticate(bus='SESSION') as connection:
+    with jeepney.io.blocking.open_dbus_connection(bus='SESSION') as connection:
         yield connection

--- a/tests/test_jeepney.py
+++ b/tests/test_jeepney.py
@@ -16,4 +16,4 @@ def test_create_error():
 def test_listen(jeepney_one_time_server, jeepney_client, jeepney_connection):
     msg = jeepney.new_method_call(jeepney_client, 'Ping', '', tuple())
     reply = jeepney_connection.send_and_get_reply(msg)
-    assert reply[0] == 'Pong!'
+    assert reply.body[0] == 'Pong!'

--- a/tests/test_jeepney.py
+++ b/tests/test_jeepney.py
@@ -1,15 +1,13 @@
 # SPDX-License-Identifier: MIT
 
 import jeepney
-import jeepney.integrate.blocking
-import jeepney.wrappers
 import pytest
 
 from dbus_objects.integration.jeepney import BlockingDBusServer
 
 
 def test_create_error():
-    with pytest.raises(jeepney.wrappers.DBusErrorResponse):
+    with pytest.raises(jeepney.DBusErrorResponse):
         BlockingDBusServer(bus='SESSION', name='org.freedesktop.DBus')
 
 


### PR DESCRIPTION
I've just released Jeepney 0.5, with an overhaul of the I/O APIs. The old interface still works for now (in fact, I was testing dbus-object as a check that I hadn't broken it), but at some point I'll clean it up in favour of the new APIs. So there's no rush to merge this if you want to keep supporting Jeepney 0.4 for a while, but I wanted to show what the changes would involve.