### PR TITLE
dbus_objects: add support for DBus properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ class ExampleObject(dbus_objects.object.DBusObject):
     def __init__(self):
         super().__init__(default_interface_root='io.github.ffy00.dbus_objects.example')
         self._bets = []
+        self._name = 'something'
 
     @dbus_objects.object.dbus_method()
     def ping(self) -> str:
@@ -44,6 +45,14 @@ class ExampleObject(dbus_objects.object.DBusObject):
         winner = random.choice(self._bets)
         self._bets = []
         return winner
+
+    @dbus_objects.object.dbus_property()
+    def name(self) -> str:
+        return self._name
+
+    @name.setter
+    def name(self, value: str):
+        self._name = value
 
 
 server = dbus_objects.integration.jeepney.BlockingDBusServer(

--- a/dbus_objects/integration/jeepney.py
+++ b/dbus_objects/integration/jeepney.py
@@ -53,7 +53,7 @@ class BlockingDBusServer(dbus_objects.integration.DBusServerBase):
 
             # TODO: validate fields are in msg
             try:
-                method = self._get_method(
+                method, descriptor = self._get_method(
                     msg.header.fields[jeepney.HeaderFields.path],
                     msg.header.fields[jeepney.HeaderFields.interface],
                     msg.header.fields[jeepney.HeaderFields.member],
@@ -72,14 +72,16 @@ class BlockingDBusServer(dbus_objects.integration.DBusServerBase):
             else:
                 msg_sig = ''
 
-            if method.dbus_signature.input != msg_sig:
+            signature_input, signature_output = descriptor.signature
+
+            if signature_input != msg_sig:
                 self.__logger.debug(
                     'got invalid signature, was expecting '
-                    f'{method.dbus_signature.input} but got {msg_sig}'
+                    f'{signature_input} but got {msg_sig}'
                 )
                 return_msg = jeepney.new_error(
                     msg, 'Client Error', 's',
-                    tuple([f'Invalid signature, expected {method.dbus_signature.input}'])
+                    tuple([f'Invalid signature, expected {signature_input}'])
                 )
             else:
                 try:
@@ -89,7 +91,7 @@ class BlockingDBusServer(dbus_objects.integration.DBusServerBase):
                 else:
                     return_msg = jeepney.new_method_return(
                         msg,
-                        method.dbus_signature.output,
+                        signature_output,
                         (return_args,) if return_args is not None else tuple()
                     )
 

--- a/dbus_objects/types.py
+++ b/dbus_objects/types.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import sys
 import typing
 
-import dbus_objects.signature
-
 
 if sys.version_info < (3, 8):
     import typing_extensions
@@ -27,12 +25,3 @@ _Variant = typing.Tuple[str, typing.Any]
 Variant = typing.TypeVar('Variant', _Variant, _Variant)
 
 MultipleReturn = typing.Tuple  # type: ignore
-
-
-class DBusMethod(typing.Protocol):
-    is_dbus_method: typing.Literal[True]
-    dbus_interface: typing.Optional[str]
-    dbus_signature: dbus_objects.signature.DBusSignature
-    dbus_parameters: typing.Dict[str, str]  # name -> signature
-    dbus_return_names: typing.List[str]
-    __call__: typing.Callable[..., typing.Any]

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -11,6 +11,7 @@ class ExampleObject(dbus_objects.object.DBusObject):
     def __init__(self):
         super().__init__(default_interface_root='io.github.ffy00.dbus_objects.example')
         self._bets = []
+        self._name = 'something'
 
     @dbus_objects.object.dbus_method()
     def ping(self) -> str:
@@ -37,6 +38,14 @@ class ExampleObject(dbus_objects.object.DBusObject):
         winner = random.choice(self._bets)
         self._bets = []
         return winner
+
+    @dbus_objects.object.dbus_property()
+    def name(self) -> str:
+        return self._name
+
+    @name.setter
+    def name(self, value: str):
+        self._name = value
 
 
 server = dbus_objects.integration.jeepney.BlockingDBusServer(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,13 +9,14 @@ import pytest
 
 from dbus_objects.integration import DBusServerBase
 from dbus_objects.integration.jeepney import BlockingDBusServer
-from dbus_objects.object import DBusObject, dbus_method
+from dbus_objects.object import DBusObject, dbus_method, dbus_property
 from dbus_objects.types import MultipleReturn
 
 
 class ExampleObject(DBusObject):
     def __init__(self):
         super().__init__(default_interface_root='com.example.object')
+        self._property = 'some property'
 
     @dbus_method()
     def example_method(self) -> str:
@@ -36,6 +37,14 @@ class ExampleObject(DBusObject):
     def multiple(self, msg: str) -> MultipleReturn[int, int]:
         print(msg)  # pragma: no cover
 
+    @dbus_property()
+    def prop(self) -> str:
+        return self._property
+
+    @prop.setter
+    def prop(self, value: str):
+        self._property = value
+
 
 @pytest.fixture(scope='session')
 def obj():
@@ -45,6 +54,11 @@ def obj():
 @pytest.fixture()
 def obj_methods(obj):
     return obj.get_dbus_methods()
+
+
+@pytest.fixture()
+def obj_properties(obj):
+    return obj.get_dbus_properties()
 
 
 @pytest.fixture()

--- a/tests/test_base_server.py
+++ b/tests/test_base_server.py
@@ -36,13 +36,13 @@ def test_register_object_duplicate(obj):
 
 
 def test_introspectable(base_server):
-    interospect = base_server._get_method(
+    introspect, _descriptor = base_server._get_method(
         '/io/github/ffy00/dbus_objects',
         'org.freedesktop.DBus.Introspectable',
         'Introspect',
     )
 
-    assert not xmldiff.main.diff_texts(interospect(), '''
+    assert not xmldiff.main.diff_texts(introspect(), '''
         <!DOCTYPE node PUBLIC
         "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
         "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd" >
@@ -51,7 +51,7 @@ def test_introspectable(base_server):
 
 
 def test_peer(base_server):
-    ping = base_server._get_method(
+    ping, _descriptor = base_server._get_method(
         '/io/github/ffy00/dbus_objects/example',
         'org.freedesktop.DBus.Peer',
         'Ping',
@@ -61,17 +61,17 @@ def test_peer(base_server):
 
 
 def test_properties(base_server):
-    get = base_server._get_method(
+    get, _descriptor_get = base_server._get_method(
         '/io/github/ffy00/dbus_objects/example',
         'org.freedesktop.DBus.Properties',
         'Get',
     )
-    set_ = base_server._get_method(
+    set_, _descriptor_set = base_server._get_method(
         '/io/github/ffy00/dbus_objects/example',
         'org.freedesktop.DBus.Properties',
         'Set',
     )
-    get_all = base_server._get_method(
+    get_all, _descriptor_get_all = base_server._get_method(
         '/io/github/ffy00/dbus_objects/example',
         'org.freedesktop.DBus.Properties',
         'GetAll',
@@ -79,4 +79,6 @@ def test_properties(base_server):
 
     assert get('interface', 'property') == ('', None)
     assert set_('interface', 'property', 'value') is None
-    assert get_all('interface') == {}
+    assert get_all('interface') == {
+        'Prop': ('s', 'some property'),
+    }

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -8,36 +8,32 @@ from dbus_objects.object import DBusObject, DBusObjectException, dbus_method
 def test_dbus_object(obj):
     assert obj.is_dbus_object
     assert obj.dbus_name == 'ExampleObject'
-    assert 'ExampleMethod' in [method.dbus_signature.name for method in obj.get_dbus_methods()]
-
-
-def test_dbus_method(obj):
-    assert obj.example_method.is_dbus_method
-    assert obj.example_method.dbus_signature
+    assert 'ExampleMethod' in [
+        descriptor.name
+        for _method, descriptor in obj.get_dbus_methods()
+    ]
 
 
 def test_call(obj_methods):
-    for method in obj_methods:
-        if method.dbus_signature.name == 'ExampleMethod':
+    for method, descriptor in obj_methods:
+        if descriptor.name == 'ExampleMethod':
             assert method() == 'test'
             return
     assert False  # pragma: no cover
 
 
 def test_signature(obj_methods):
-    for method in obj_methods:
-        if method.dbus_signature.name == 'ExampleMethod':
-            assert method.dbus_signature.input == ''
-            assert method.dbus_signature.output == 's'
+    for _method, descriptor in obj_methods:
+        if descriptor.name == 'ExampleMethod':
+            assert descriptor.signature == ('', 's')
             return
     assert False  # pragma: no cover
 
 
 def test_signature_multiple_return(obj_methods):
-    for method in obj_methods:
-        if method.dbus_signature.name == 'Multiple':
-            assert method.dbus_signature.input == 's'
-            assert method.dbus_signature.output == 'ii'
+    for _method, descriptor in obj_methods:
+        if descriptor.name == 'Multiple':
+            assert descriptor.signature == ('s', 'ii')
             return
     assert False  # pragma: no cover
 
@@ -50,3 +46,13 @@ def test_no_interface():
 
     with pytest.raises(DBusObjectException):
         list(TestObject().get_dbus_methods())
+
+
+def test_property(obj_properties):
+    for getter, setter, descriptor in obj_properties:
+        if descriptor.name == 'Prop':
+            assert descriptor.signature == 's'
+            setter('something else')
+            assert getter() == 'something else'
+            return
+    assert False  # pragma: no cover


### PR DESCRIPTION
This required a major refactoring of the decorators, we now use object
descriptors.

https://docs.python.org/3/reference/datamodel.html#object.__get__
https://docs.python.org/3/howto/descriptor.html

The current XML generation is incorrect, properties are annotated as
methods. That should be fixed in a later commit.

dbus_objects.signature should be refactored because having DBusSignature
class like we currently do does not make sense with the new storage
model. Most of the glue code there should be moved to the descriptors.
This will also allow us to cleanly fix the wrong XML generation for
properties.

Signed-off-by: Filipe Laíns <lains@riseup.net>