### PR TITLE
setup.cfg: exclude 'tests' directory from package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,9 @@ install_requires =
     treelib
     typing_extensions ; python_version < '3.8'
 
+[options.packages.find]
+exclude = tests
+
 [options.extras_require]
 jeepney =
     jeepney >= 0.5


### PR DESCRIPTION
This avoids a top-level 'tests' module being installed by the package.