### PR TITLE
integration: remove xmlns:doc spec from the introspection XML

### DIFF
--- a/dbus_objects/integration/__init__.py
+++ b/dbus_objects/integration/__init__.py
@@ -48,6 +48,7 @@ class _Introspectable(dbus_objects.object.DBusObject):
 
     @dbus_objects.object.dbus_method(return_names=('xml',))
     def introspect(self) -> str:  # noqa: C901
+        #xml = ET.Element('node', {'xmlns:doc': 'http://www.freedesktop.org/dbus/1.0/doc.dtd'}) # See: FFY00/dbus-objects#20.
         xml = ET.Element('node')
         interfaces: Dict[str, ET.Element] = {}
 

--- a/dbus_objects/integration/__init__.py
+++ b/dbus_objects/integration/__init__.py
@@ -48,7 +48,7 @@ class _Introspectable(dbus_objects.object.DBusObject):
 
     @dbus_objects.object.dbus_method(return_names=('xml',))
     def introspect(self) -> str:  # noqa: C901
-        xml = ET.Element('node', {'xmlns:doc': 'http://www.freedesktop.org/dbus/1.0/doc.dtd'})
+        xml = ET.Element('node')
         interfaces: Dict[str, ET.Element] = {}
 
         def get_interface(name: str) -> ET.Element:

--- a/dbus_objects/integration/__init__.py
+++ b/dbus_objects/integration/__init__.py
@@ -48,7 +48,7 @@ class _Introspectable(dbus_objects.object.DBusObject):
 
     @dbus_objects.object.dbus_method(return_names=('xml',))
     def introspect(self) -> str:  # noqa: C901
-        #xml = ET.Element('node', {'xmlns:doc': 'http://www.freedesktop.org/dbus/1.0/doc.dtd'}) # See: FFY00/dbus-objects#20.
+        # xml = ET.Element('node', {'xmlns:doc': 'http://www.freedesktop.org/dbus/1.0/doc.dtd'}) # See: FFY00/dbus-objects#20.
         xml = ET.Element('node')
         interfaces: Dict[str, ET.Element] = {}
 


### PR DESCRIPTION
As noted in FFY00/dbus-objects#20, feel free to reject this if you think it should be addressed in `busctl` or it's just not worth fixing.