### PR TITLE
ci: only run on master

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,12 @@
 name: tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   pytest:


### PR DESCRIPTION
This prevents the CI from running on the branch I push to, as a push
event, and on master, as a pull_request event, which will essentially
run it two times.

Signed-off-by: Filipe Laíns <lains@riseup.net>