### PR TITLE
jeepney: increase blocking timeout

### DIFF
--- a/dbus_objects/integration/jeepney.py
+++ b/dbus_objects/integration/jeepney.py
@@ -108,7 +108,7 @@ class BlockingDBusServer(dbus_objects.integration.DBusServerBase):
         '''
         self._conn.close()
 
-    def listen(self, delay: float = 0.01, event: Optional[threading.Event] = None) -> None:
+    def listen(self, delay: float = 0.1, event: Optional[threading.Event] = None) -> None:
         '''
         Start listening and handling messages
 


### PR DESCRIPTION
Previously, we were forcing the program to sleep so that we did not pin
up the cpu. Now that jeepney will handle the loop with a timeout, we can
increase the value as it is the timeout value instead of the sleep
duration.

Signed-off-by: Filipe Laíns <lains@riseup.net>