### PR TITLE
ci: use codecov Github action v2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,3 +43,4 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: PYTHON
+          files: .nox/*/coverage-*.xml


### PR DESCRIPTION
The v1 action is deprecated due to security concerns, and will stop working in a few months:

https://github.com/marketplace/actions/codecov
https://about.codecov.io/blog/introducing-codecovs-new-uploader/